### PR TITLE
Allow multiple uses in a single workflow

### DIFF
--- a/.github/workflows/golang-binary.yaml
+++ b/.github/workflows/golang-binary.yaml
@@ -86,6 +86,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.binary-prefix }}${{ inputs.os }}-${{ inputs.arch }}${{ steps.sanitize-artifact-postfix.outputs.value }}
-        path: ./${{ inputs.working-directory }}${{ github.repository }}*
+        path: ${{ inputs.working-directory }}${{ github.repository }}*
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/golang-binary.yaml
+++ b/.github/workflows/golang-binary.yaml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      working-directory:
+        required: false
+        default: "./"
+        type: string
+        description: "Working directory to base all other paths on"
       mod-path:
         required: false
         default: "./go.mod"
@@ -41,6 +46,9 @@ jobs:
   binary:
     name: Binary
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
 
     - name: Checkout code

--- a/.github/workflows/golang-binary.yaml
+++ b/.github/workflows/golang-binary.yaml
@@ -79,6 +79,7 @@ jobs:
           source: ${{ inputs.artifact-postfix }} 
           find: "/"
           replace: "-"
+          replaceAll: true
 
     - name: Store binaries
       uses: actions/upload-artifact@v4

--- a/.github/workflows/golang-binary.yaml
+++ b/.github/workflows/golang-binary.yaml
@@ -60,6 +60,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
+        cache-dependency-path: "${{ inputs.working-directory }}go.sum"
 
     - name: Get dependencies
       run: go mod download

--- a/.github/workflows/golang-binary.yaml
+++ b/.github/workflows/golang-binary.yaml
@@ -5,7 +5,7 @@ on:
         required: false
         default: "./"
         type: string
-        description: "Working directory to base all other paths on"
+        description: "Working directory to base all other paths on. Should end with a slash (/)"
       mod-path:
         required: false
         default: "./go.mod"
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
+        go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
 
     - name: Get dependencies
       run: go mod download
@@ -85,6 +85,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.binary-prefix }}${{ inputs.os }}-${{ inputs.arch }}${{ steps.sanitize-artifact-postfix.outputs.value }}
-        path: ./${{ inputs.working-directory }}/${{ github.repository }}*
+        path: ./${{ inputs.working-directory }}${{ github.repository }}*
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/golang-binary.yaml
+++ b/.github/workflows/golang-binary.yaml
@@ -46,9 +46,6 @@ jobs:
   binary:
     name: Binary
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
     steps:
 
     - name: Checkout code
@@ -57,21 +54,23 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: ${{ inputs.mod-path }}
+        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
 
     - name: Get dependencies
       run: go mod download
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Build
       run: go build ${{ inputs.build-flags }} -o "./${{ github.repository }}-${{ inputs.os }}-${{ inputs.arch }}.${{ (inputs.os == 'windows' && 'exe') || 'bin' }}" ${{ inputs.source-path }}
       env:
         GOOS: ${{ inputs.os }}
         GOARCH: ${{ inputs.arch }}
+      working-directory: ${{ inputs.working-directory }}
   
     - name: Store binaries
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.binary-prefix }}${{ inputs.os }}-${{ inputs.arch }}
-        path: ./${{ github.repository }}*
+        path: ./${{ inputs.working-directory }}/${{ github.repository }}*
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/golang-binary.yaml
+++ b/.github/workflows/golang-binary.yaml
@@ -71,11 +71,19 @@ jobs:
         GOOS: ${{ inputs.os }}
         GOARCH: ${{ inputs.arch }}
       working-directory: ${{ inputs.working-directory }}
-  
+
+    - name: Sanitize artifact postfix
+      id: sanitize-artifact-postfix
+      uses: mad9000/actions-find-and-replace-string@5
+      with:
+          source: ${{ inputs.artifact-postfix }} 
+          find: "/"
+          replace: "-"
+
     - name: Store binaries
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.binary-prefix }}${{ inputs.os }}-${{ inputs.arch }}${{ inputs.artifact-postfix }}
+        name: ${{ inputs.binary-prefix }}${{ inputs.os }}-${{ inputs.arch }}${{ steps.sanitize-artifact-postfix.outputs.value }}
         path: ./${{ inputs.working-directory }}/${{ github.repository }}*
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/golang-binary.yaml
+++ b/.github/workflows/golang-binary.yaml
@@ -41,6 +41,11 @@ on:
         default: "Binaries-"
         type: string
         description: "Prefix for the binary name"
+      artifact-postfix:
+        required: false
+        default: ""
+        type: string
+        description: "Postfix to append to the artifact name. Should start with a dash (-)"
 
 jobs:
   binary:
@@ -70,7 +75,7 @@ jobs:
     - name: Store binaries
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.binary-prefix }}${{ inputs.os }}-${{ inputs.arch }}
+        name: ${{ inputs.binary-prefix }}${{ inputs.os }}-${{ inputs.arch }}${{ inputs.artifact-postfix }}
         path: ./${{ inputs.working-directory }}/${{ github.repository }}*
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/golang-linting.yaml
+++ b/.github/workflows/golang-linting.yaml
@@ -26,9 +26,6 @@ jobs:
   linting:
     name: Linting
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
     steps:
 
     - name: Checkout code
@@ -37,20 +34,22 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: ${{ inputs.mod-path }}
+        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
 
     - name: Check formatting
       run: go fmt ${{ inputs.source-path }}
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Check vet
       run: go vet ${{ inputs.source-path }}
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Check linting
       uses: golangci/golangci-lint-action@v4
       with:
         version: latest
         skip-pkg-cache: true
-        args: --issues-exit-code=0 --out-format checkstyle -v ${{ inputs.source-path }} > ./lint.out
+        args: --issues-exit-code=0 --out-format checkstyle -v ${{ inputs.working-directory }}/${{ inputs.source-path }} > ./lint.out
 
     - name: Store linting report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/golang-linting.yaml
+++ b/.github/workflows/golang-linting.yaml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      working-directory:
+        required: false
+        default: "./"
+        type: string
+        description: "Working directory to base all other paths on"
       mod-path:
         required: false
         default: "./go.mod"
@@ -21,6 +26,9 @@ jobs:
   linting:
     name: Linting
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
 
     - name: Checkout code

--- a/.github/workflows/golang-linting.yaml
+++ b/.github/workflows/golang-linting.yaml
@@ -5,7 +5,7 @@ on:
         required: false
         default: "./"
         type: string
-        description: "Working directory to base all other paths on"
+        description: "Working directory to base all other paths on. Should end with a slash (/)"
       mod-path:
         required: false
         default: "./go.mod"
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
+        go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
 
     - name: Check formatting
       run: go fmt ${{ inputs.source-path }}
@@ -49,7 +49,7 @@ jobs:
       with:
         version: latest
         skip-pkg-cache: true
-        args: --issues-exit-code=0 --out-format checkstyle -v ${{ inputs.working-directory }}/${{ inputs.source-path }} > ./lint.out
+        args: --issues-exit-code=0 --out-format checkstyle -v ${{ inputs.working-directory }}${{ inputs.source-path }} > ./lint.out
 
     - name: Store linting report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/golang-linting.yaml
+++ b/.github/workflows/golang-linting.yaml
@@ -35,6 +35,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
+        cache-dependency-path: "${{ inputs.working-directory }}go.sum"
 
     - name: Check formatting
       run: go fmt ${{ inputs.source-path }}

--- a/.github/workflows/golang-security.yaml
+++ b/.github/workflows/golang-security.yaml
@@ -40,7 +40,8 @@ jobs:
     - name: Govulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-package: "${{ inputs.working-directory }}..."
+        go-package: "./..."
+        work-dir: ${{ inputs.working-directory }}
 
   SAST:
     name: SAST

--- a/.github/workflows/golang-security.yaml
+++ b/.github/workflows/golang-security.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
-          args: '-no-fail -fmt sarif -out gosec.sarif ./${{ inputs.working-directory }}...'
+          args: '-no-fail -fmt sarif -out gosec.sarif ${{ inputs.working-directory }}...'
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/golang-security.yaml
+++ b/.github/workflows/golang-security.yaml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
+        cache-dependency-path: "${{ inputs.working-directory }}go.sum"
 
     - name: Write Go List
       run: go list -json -m > go.list
@@ -53,6 +54,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
+          cache-dependency-path: "${{ inputs.working-directory }}go.sum"
 
       # GoSec
       - name: Run Gosec Security Scanner

--- a/.github/workflows/golang-security.yaml
+++ b/.github/workflows/golang-security.yaml
@@ -5,7 +5,7 @@ on:
         required: false
         default: "./"
         type: string
-        description: "Working directory to base all other paths on"
+        description: "Working directory to base all other paths on. Should end with a slash (/)"
       mod-path:
         required: false
         default: "./go.mod"
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
+        go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
 
     - name: Write Go List
       run: go list -json -m > go.list
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
+          go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
 
       # GoSec
       - name: Run Gosec Security Scanner

--- a/.github/workflows/golang-security.yaml
+++ b/.github/workflows/golang-security.yaml
@@ -21,9 +21,6 @@ jobs:
   SCA:
     name: SCA
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
     steps:
 
     - name: Checkout code
@@ -32,10 +29,11 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: ${{ inputs.mod-path }}
+        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
 
     - name: Write Go List
       run: go list -json -m > go.list
+      working-directory: ${{ inputs.working-directory }}
 
     # TODO check on progress of https://github.com/golang/go/issues/61347
     - name: Govulncheck
@@ -46,9 +44,6 @@ jobs:
   SAST:
     name: SAST
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
     steps:
 
       - name: Checkout code
@@ -57,13 +52,13 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version-file: ${{ inputs.mod-path }}
+          go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
 
       # GoSec
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
-          args: '-no-fail -fmt sarif -out gosec.sarif ./...'
+          args: '-no-fail -fmt sarif -out gosec.sarif ./${{ inputs.working-directory }}...'
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/golang-security.yaml
+++ b/.github/workflows/golang-security.yaml
@@ -39,7 +39,7 @@ jobs:
     - name: Govulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-package: ./...
+        go-package: "./${{ inputs.working-directory }}..."
 
   SAST:
     name: SAST

--- a/.github/workflows/golang-security.yaml
+++ b/.github/workflows/golang-security.yaml
@@ -40,7 +40,7 @@ jobs:
     - name: Govulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-package: "./${{ inputs.working-directory }}..."
+        go-package: "${{ inputs.working-directory }}..."
 
   SAST:
     name: SAST

--- a/.github/workflows/golang-security.yaml
+++ b/.github/workflows/golang-security.yaml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      working-directory:
+        required: false
+        default: "./"
+        type: string
+        description: "Working directory to base all other paths on"
       mod-path:
         required: false
         default: "./go.mod"
@@ -16,6 +21,9 @@ jobs:
   SCA:
     name: SCA
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
 
     - name: Checkout code
@@ -38,6 +46,9 @@ jobs:
   SAST:
     name: SAST
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
 
       - name: Checkout code

--- a/.github/workflows/golang-security.yaml
+++ b/.github/workflows/golang-security.yaml
@@ -42,6 +42,7 @@ jobs:
       with:
         go-package: "./..."
         work-dir: ${{ inputs.working-directory }}
+        go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
 
   SAST:
     name: SAST

--- a/.github/workflows/golang-testing-small.yaml
+++ b/.github/workflows/golang-testing-small.yaml
@@ -41,6 +41,11 @@ on:
         default: 2
         type: number
         description: "Number of days to keep the test results in the artifact store"
+      artifact-postfix:
+        required: false
+        default: ""
+        type: string
+        description: "Postfix to append to the artifact name. Should start with a dash (-)"
 
 jobs:
   test-small-correctness:
@@ -69,7 +74,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
-        name: Test small reports - Correctness
+        name: Test small reports - Correctness${{ inputs.artifact-postfix }}
         path: |
           ./${{ inputs.working-directory }}/correctness-tests.xml
           ./${{ inputs.working-directory }}/correctness-tests-coverage.out
@@ -103,7 +108,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
-        name: Test small reports - Performance
+        name: Test small reports - Performance${{ inputs.artifact-postfix }}
         path: ./${{ inputs.working-directory }}/performance-tests.txt
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/golang-testing-small.yaml
+++ b/.github/workflows/golang-testing-small.yaml
@@ -61,6 +61,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
+        cache-dependency-path: "${{ inputs.working-directory }}go.sum"
 
     - name: Get dependencies
       run: go mod download && go install gotest.tools/gotestsum@latest
@@ -103,6 +104,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
+        cache-dependency-path: "${{ inputs.working-directory }}go.sum"
 
     - name: Get dependencies
       run: go mod download
@@ -144,6 +146,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
+        cache-dependency-path: "${{ inputs.working-directory }}go.sum"
 
     - name: Get dependencies
       run: go mod download

--- a/.github/workflows/golang-testing-small.yaml
+++ b/.github/workflows/golang-testing-small.yaml
@@ -5,7 +5,7 @@ on:
         required: false
         default: "./"
         type: string
-        description: "Working directory to base all other paths on"
+        description: "Working directory to base all other paths on. Should end with a slash (/)"
       mod-path:
         required: false
         default: "./go.mod"
@@ -60,7 +60,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
+        go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
 
     - name: Get dependencies
       run: go mod download && go install gotest.tools/gotestsum@latest
@@ -85,8 +85,8 @@ jobs:
       with:
         name: Test small reports - Correctness${{ steps.sanitize-artifact-postfix.outputs.value }}
         path: |
-          ./${{ inputs.working-directory }}/correctness-tests.xml
-          ./${{ inputs.working-directory }}/correctness-tests-coverage.out
+          ./${{ inputs.working-directory }}correctness-tests.xml
+          ./${{ inputs.working-directory }}correctness-tests-coverage.out
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}
 
@@ -102,7 +102,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
+        go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
 
     - name: Get dependencies
       run: go mod download
@@ -127,7 +127,7 @@ jobs:
       if: ${{ !cancelled() }}
       with:
         name: Test small reports - Performance${{ steps.sanitize-artifact-postfix.outputs.value }}
-        path: ./${{ inputs.working-directory }}/performance-tests.txt
+        path: ./${{ inputs.working-directory }}performance-tests.txt
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}
 
@@ -143,7 +143,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
+        go-version-file: "${{ inputs.working-directory }}${{ inputs.mod-path }}"
 
     - name: Get dependencies
       run: go mod download

--- a/.github/workflows/golang-testing-small.yaml
+++ b/.github/workflows/golang-testing-small.yaml
@@ -77,6 +77,7 @@ jobs:
           source: ${{ inputs.artifact-postfix }} 
           find: "/"
           replace: "-"
+          replaceAll: true
 
     - name: Store test reports
       uses: actions/upload-artifact@v4
@@ -119,6 +120,7 @@ jobs:
           source: ${{ inputs.artifact-postfix }} 
           find: "/"
           replace: "-"
+          replaceAll: true
 
     - name: Store test reports
       uses: actions/upload-artifact@v4

--- a/.github/workflows/golang-testing-small.yaml
+++ b/.github/workflows/golang-testing-small.yaml
@@ -70,11 +70,19 @@ jobs:
       run: gotestsum --packages=${{ inputs.test-path }} --junitfile="./correctness-tests.xml" -- -coverprofile="./correctness-tests-coverage.out" -count=${{ inputs.test-count }} -race
       working-directory: ${{ inputs.working-directory }}
 
+    - name: Sanitize artifact postfix
+      id: sanitize-artifact-postfix
+      uses: mad9000/actions-find-and-replace-string@5
+      with:
+          source: ${{ inputs.artifact-postfix }} 
+          find: "/"
+          replace: "-"
+
     - name: Store test reports
       uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
-        name: Test small reports - Correctness${{ inputs.artifact-postfix }}
+        name: Test small reports - Correctness${{ steps.sanitize-artifact-postfix.outputs.value }}
         path: |
           ./${{ inputs.working-directory }}/correctness-tests.xml
           ./${{ inputs.working-directory }}/correctness-tests-coverage.out
@@ -104,11 +112,19 @@ jobs:
       run: go test -bench="." -count=${{ inputs.test-count }} ${{ inputs.test-path }} > ./performance-tests.txt
       working-directory: ${{ inputs.working-directory }}
 
+    - name: Sanitize artifact postfix
+      id: sanitize-artifact-postfix
+      uses: mad9000/actions-find-and-replace-string@5
+      with:
+          source: ${{ inputs.artifact-postfix }} 
+          find: "/"
+          replace: "-"
+
     - name: Store test reports
       uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
-        name: Test small reports - Performance${{ inputs.artifact-postfix }}
+        name: Test small reports - Performance${{ steps.sanitize-artifact-postfix.outputs.value }}
         path: ./${{ inputs.working-directory }}/performance-tests.txt
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/golang-testing-small.yaml
+++ b/.github/workflows/golang-testing-small.yaml
@@ -46,9 +46,6 @@ jobs:
   test-small-correctness:
     name: Small Tests - Correctness
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
     if: ${{ inputs.enable-correctness }}
     steps:
 
@@ -58,13 +55,15 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: ${{ inputs.mod-path }}
+        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
 
     - name: Get dependencies
       run: go mod download && go install gotest.tools/gotestsum@latest
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Correctness tests
       run: gotestsum --packages=${{ inputs.test-path }} --junitfile="./correctness-tests.xml" -- -coverprofile="./correctness-tests-coverage.out" -count=${{ inputs.test-count }} -race
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Store test reports
       uses: actions/upload-artifact@v4
@@ -72,17 +71,14 @@ jobs:
       with:
         name: Test small reports - Correctness
         path: |
-          ./correctness-tests.xml
-          ./correctness-tests-coverage.out
+          ./${{ inputs.working-directory }}/correctness-tests.xml
+          ./${{ inputs.working-directory }}/correctness-tests-coverage.out
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}
 
   test-small-performance:
     name: Small Tests - Performance
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
     if: ${{ inputs.enable-performance }}
     steps:
 
@@ -92,30 +88,29 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: ${{ inputs.mod-path }}
+        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
 
     - name: Get dependencies
       run: go mod download
+      working-directory: ${{ inputs.working-directory }}
 
     # TODO Add test for on PR, run performance test on HEAD and PR, and check diff
     - name: Performance tests
       run: go test -bench="." -count=${{ inputs.test-count }} ${{ inputs.test-path }} > ./performance-tests.txt
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Store test reports
       uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
         name: Test small reports - Performance
-        path: ./performance-tests.txt
+        path: ./${{ inputs.working-directory }}/performance-tests.txt
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}
 
   test-small-fuzz:
     name: Small Tests - Fuzz
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ inputs.working-directory }}
     if: ${{ inputs.enable-fuzz }}
     steps:
 
@@ -125,10 +120,12 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version-file: ${{ inputs.mod-path }}
+        go-version-file: "${{ inputs.working-directory }}/${{ inputs.mod-path }}"
 
     - name: Get dependencies
       run: go mod download
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Fuzz tests
       run: find . -maxdepth 3 -type d \( ! -name . \) -not -path "./.git/*" -exec bash -c "cd '{}' && go test --fuzz=. --fuzztime=10s" \;
+      working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/golang-testing-small.yaml
+++ b/.github/workflows/golang-testing-small.yaml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      working-directory:
+        required: false
+        default: "./"
+        type: string
+        description: "Working directory to base all other paths on"
       mod-path:
         required: false
         default: "./go.mod"
@@ -41,6 +46,9 @@ jobs:
   test-small-correctness:
     name: Small Tests - Correctness
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     if: ${{ inputs.enable-correctness }}
     steps:
 
@@ -72,6 +80,9 @@ jobs:
   test-small-performance:
     name: Small Tests - Performance
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     if: ${{ inputs.enable-performance }}
     steps:
 
@@ -102,6 +113,9 @@ jobs:
   test-small-fuzz:
     name: Small Tests - Fuzz
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     if: ${{ inputs.enable-fuzz }}
     steps:
 

--- a/.github/workflows/golang-testing-small.yaml
+++ b/.github/workflows/golang-testing-small.yaml
@@ -86,8 +86,8 @@ jobs:
       with:
         name: Test small reports - Correctness${{ steps.sanitize-artifact-postfix.outputs.value }}
         path: |
-          ./${{ inputs.working-directory }}correctness-tests.xml
-          ./${{ inputs.working-directory }}correctness-tests-coverage.out
+          ${{ inputs.working-directory }}correctness-tests.xml
+          ${{ inputs.working-directory }}correctness-tests-coverage.out
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}
 
@@ -129,7 +129,7 @@ jobs:
       if: ${{ !cancelled() }}
       with:
         name: Test small reports - Performance${{ steps.sanitize-artifact-postfix.outputs.value }}
-        path: ./${{ inputs.working-directory }}performance-tests.txt
+        path: ${{ inputs.working-directory }}performance-tests.txt
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}
 


### PR DESCRIPTION
A consumer can use the golang workflows multiple times, for instance in a matrix.

Previously artifacts being uploaded would have had the same name and therefore errored on the second+ run. Now each can optionally be given a unique name allowing for multiple runs within the same workflow.